### PR TITLE
SN-134

### DIFF
--- a/backend/workspaces/views.py
+++ b/backend/workspaces/views.py
@@ -169,6 +169,8 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
         """
         API for getting all projects of a workspace
         """
+        only_active=str(request.GET.get('only_active','false'))
+        only_active=True if only_active=='true' else False
         try:
             workspace = Workspace.objects.get(pk=pk)
         except Workspace.DoesNotExist:
@@ -177,6 +179,10 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
             projects = Project.objects.filter(users=request.user, workspace_id=workspace)
         else:
             projects = Project.objects.filter(workspace_id=workspace)
+        
+        if only_active==True:
+            projects=projects.filter(is_archived=False)
+        
         serializer = ProjectSerializer(projects, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
# Description

made the /workspaces/{id}/projects/ endpoint to return not archived projects by setting query_params only_active=true
else it returns all projects.