### PR TITLE
fix: add migrations for `verbose_name` in projects

### DIFF
--- a/backend/projects/migrations/0026_alter_project_src_language_and_more.py
+++ b/backend/projects/migrations/0026_alter_project_src_language_and_more.py
@@ -12,11 +12,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name='project',
-            name='id',
-            field=models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID'),
-        ),
-        migrations.AlterField(
-            model_name='project',
             name='src_language',
             field=models.CharField(blank=True, choices=[('English', 'English'), ('Assamese', 'Assamese'), ('Bengali', 'Bengali'), ('Bodo', 'Bodo'), ('Dogri', 'Dogri'), ('Gujarati', 'Gujarati'), ('Hindi', 'Hindi'), ('Kannada', 'Kannada'), ('Kashmiri', 'Kashmiri'), ('Konkani', 'Konkani'), ('Maithili', 'Maithili'), ('Malayalam', 'Malayalam'), ('Manipuri', 'Manipuri'), ('Marathi', 'Marathi'), ('Nepali', 'Nepali'), ('Odia', 'Odia'), ('Punjabi', 'Punjabi'), ('Sanskrit', 'Sanskrit'), ('Santali', 'Santali'), ('Sindhi', 'Sindhi'), ('Sinhala', 'Sinhala'), ('Tamil', 'Tamil'), ('Telugu', 'Telugu'), ('Urdu', 'Urdu')], help_text='Source language of the project', max_length=50, null=True, verbose_name='Source Language'),
         ),
@@ -24,10 +19,5 @@ class Migration(migrations.Migration):
             model_name='project',
             name='tgt_language',
             field=models.CharField(blank=True, choices=[('English', 'English'), ('Assamese', 'Assamese'), ('Bengali', 'Bengali'), ('Bodo', 'Bodo'), ('Dogri', 'Dogri'), ('Gujarati', 'Gujarati'), ('Hindi', 'Hindi'), ('Kannada', 'Kannada'), ('Kashmiri', 'Kashmiri'), ('Konkani', 'Konkani'), ('Maithili', 'Maithili'), ('Malayalam', 'Malayalam'), ('Manipuri', 'Manipuri'), ('Marathi', 'Marathi'), ('Nepali', 'Nepali'), ('Odia', 'Odia'), ('Punjabi', 'Punjabi'), ('Sanskrit', 'Sanskrit'), ('Santali', 'Santali'), ('Sindhi', 'Sindhi'), ('Sinhala', 'Sinhala'), ('Tamil', 'Tamil'), ('Telugu', 'Telugu'), ('Urdu', 'Urdu')], help_text='Target language of the project', max_length=50, null=True, verbose_name='Target Language'),
-        ),
-        migrations.AlterField(
-            model_name='projecttaskrequestlock',
-            name='id',
-            field=models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID'),
         ),
     ]


### PR DESCRIPTION
# Description

Verbose Name for src_language and tgt_language were added but the migrations were not present.
Added the same for those

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests / checks that you performed to verify your changes. Provide instructions so we can reproduce. Please delete options that are not relevant.

- [ ] Tested the API endpoint on Swagger with the 'Try it out' feature
- [ ] Tested the Models using the Django Shell
- [x] Any other tests you performed for checking edge cases.
- [x] Any other tests you performed for checking exceptions.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Checklist for Models

If you added new models / made changes to exsting models, please fill this checklist. 

- [ ] The primary key of the Model is an AutoField
- [ ] I have defined the `__str__` method for the Model
- [ ] If the field is optional, it has been spcified explicitly
- [x] I have added a `verbose_name` for each Field.
- [ ] I have added a docstring for the Model
- [ ] The model is registered on Admin Site.
- [ ] I have pushed the migrations.

## Checklist for API

If you added new api endpoints / made changes to exsting endpoints, please fill this checklist. 

- [ ] The endpoint is accessible through Swagger.
- [ ] The endpoint supports permissions and authentication for different roles.
- [ ] All exceptions have been handled and appropriate status code is returned to the user.
- [ ] I have added docstrings for ViewSets / Serializers.
