### PR TITLE
language filter added to user_analytics  and project_analytics  apis in workspace 

### DIFF
--- a/backend/workspaces/views.py
+++ b/backend/workspaces/views.py
@@ -262,6 +262,7 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
         from_date = from_date + ' 00:00'
         to_date = to_date + ' 23:59'
         tgt_language = request.data.get('tgt_language')
+        project_type = request.data.get("project_type")
 
         cond, invalid_message = is_valid_date(from_date)
         if not cond:
@@ -277,8 +278,12 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
         if start_date > end_date:
             return Response({"message": "'To' Date should be after 'From' Date"}, status=status.HTTP_400_BAD_REQUEST)
 
-        project_type = request.data.get("project_type")
-        projects_objs = Project.objects.filter(workspace_id=pk, project_type = project_type,tgt_language = tgt_language)
+        selected_language = "No Language Selected"
+        if tgt_language == None :
+            projects_objs = Project.objects.filter(workspace_id=pk, project_type = project_type)
+        else :
+            selected_language = tgt_language
+            projects_objs = Project.objects.filter(workspace_id=pk, project_type = project_type,tgt_language = tgt_language)
         final_result=[]
         if projects_objs.count() !=0:
             for proj in projects_objs:
@@ -306,7 +311,7 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
                 result = {
                     "Project Id" : project_id,
                     "Project Name" : project_name,
-                    "Language" : tgt_language,
+                    "Language" : selected_language,
                     "Project Type" : project_type,
                     "Total No.Of Tasks" : total_tasks,
                     "Total No.Of Annotators Assigned" : no_of_annotators_assigned,
@@ -314,7 +319,7 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
                     "Total No.Of Unlabeled Tasks" : un_labeled_count,
                     "Total No.Of Skipped Tasks": skipped_count,
                     "Total No.Of Draft Tasks" : dropped_tasks,
-                    "Project Progress" : project_progress
+                    "Project Progress" : round(project_progress,3)
                     }
                 final_result.append(result)
         ret_status = status.HTTP_200_OK
@@ -371,10 +376,14 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
         project_type = request.data.get("project_type")
         project_type_lower =  project_type.lower()
         is_translation_project = True if  "translation" in  project_type_lower  else False
-
+        selected_language = "No Language Selected"
         final_result =[]
         for index,each_user in enumerate(users_id):
-            projects_objs = Project.objects.filter(workspace_id=pk, users = each_user,project_type = project_type,tgt_language = tgt_language)
+            if tgt_language == None :
+                projects_objs = Project.objects.filter(workspace_id=pk, users = each_user,project_type = project_type)
+            else :
+                selected_language = tgt_language
+                projects_objs = Project.objects.filter(workspace_id=pk, users = each_user,project_type = project_type,tgt_language = tgt_language)
             project_count = projects_objs.count()
             proj_ids = [eachid['id'] for eachid in projects_objs.values('id')]
             
@@ -425,7 +434,7 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
                 result = {
                     "Username":name,
                     "Email":email,
-                    "Language" : tgt_language,
+                    "Language" : selected_language,
                     "No.of Projects":project_count,
                     "Annotated Tasks" : annotated_tasks ,
                     "Average Annotation Time (In Seconds)" : round(avg_lead_time, 2),
@@ -439,7 +448,7 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
                 result = {
                     "Username":name,
                     "Email":email,
-                    "Language" : tgt_language,
+                    "Language" : selected_language,
                     "No.of Projects":project_count,
                     "Annotated Tasks" : annotated_tasks ,
                     "Average Annotation Time (In Seconds)" : round(avg_lead_time, 2),


### PR DESCRIPTION
## Description

Options we can support in Workspace level reporting:

Checking the progress of annotators added to the workspace by filtering the project type.

Checking the progress of projects inside the workspace by filtering the project type.

Checking the progress of annotators added to the workspace by filtering the project language. [To be done once we have a mapping for project to in-out lang ready]

Checking the progress of projects inside the workspace by filtering the project language. [To be done once we have a mapping for project to in-out lang ready]



API endpoints : 
------------------
http://localhost:8000/workspaces/1/user_analytics/
http://localhost:8000/workspaces/1/project_analytics/

body ( Body is same for both APIs ): 
------------------------------------------------------------

{

"project_type" : "ContextualTranslationEditing",
"from_date":"2022-05-23",
"to_date" : "2022-06-15",
"tgt_language" : "Bengali"
}






