### PR TITLE
user added just as a reviewer can get the projects

### DIFF
--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -286,7 +286,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
                     organization_id=request.user.organization
                 )
             else:
-                projects = self.queryset.filter(users=request.user)
+                projects = self.queryset.filter(users=request.user)|self.queryset.filter(annotation_reviewers=request.user)
             projects_json = self.serializer_class(projects, many=True)
             return Response(projects_json.data, status=status.HTTP_200_OK)
         except Exception:


### PR DESCRIPTION
When a user is added just as a reviewer and not a member to a project, that project has to be displayed in the initial project cards dashboard


