### PR TITLE
fix: calculate annotation time and word count for labeled tasks

### DIFF
--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -349,7 +349,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
         project = Project.objects.filter(pk=pk).first()
         if not project:
-            return Reponse({"message": "Project does not exist"}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": "Project does not exist"}, status=status.HTTP_404_NOT_FOUND)
 
         if project.frozen_users.filter(id=user.id).exists():
             return Response({"message": "User is already frozen in this project"}, status=status.HTTP_400_BAD_REQUEST)
@@ -956,16 +956,27 @@ class ProjectViewSet(viewsets.ModelViewSet):
                 items.append(("Draft Tasks", total_draft_tasks_count))
 
                 if is_translation_project :
-                    total_word_count_list = [no_of_words(each_task.data['input_text']) for  each_task in annotated_tasks_objs]
-                    total_word_count = sum(total_word_count_list)
+                    if proj.enable_task_reviews:
+                        total_word_count_list = [no_of_words(each_task.data['input_text']) for  each_task in labeled_tasks]
+                        total_word_count = sum(total_word_count_list)
+                    else:
+                        total_word_count_list = [no_of_words(each_task.data['input_text']) for  each_task in annotated_tasks_objs]
+                        total_word_count = sum(total_word_count_list)
 
                     items.append(("Word Count" , total_word_count))
 
 
-                lead_time_annotated_tasks = [ eachtask.correct_annotation.lead_time for eachtask in annotated_tasks_objs]
-                avg_lead_time = 0
-                if len(lead_time_annotated_tasks) > 0 :
-                    avg_lead_time = sum(lead_time_annotated_tasks) / len(lead_time_annotated_tasks)
+                if proj.enable_task_reviews:
+                    annotations = Annotation.objects.filter(completed_by=each_user,task__in=labeled_tasks)
+                    lead_time_annotated_tasks = [annot.lead_time for annot in annotations]
+                    avg_lead_time = 0
+                    if len(lead_time_annotated_tasks) > 0 :
+                        avg_lead_time = sum(lead_time_annotated_tasks) / len(lead_time_annotated_tasks)
+                else:
+                    lead_time_annotated_tasks = [ eachtask.correct_annotation.lead_time for eachtask in annotated_tasks_objs]
+                    avg_lead_time = 0
+                    if len(lead_time_annotated_tasks) > 0 :
+                        avg_lead_time = sum(lead_time_annotated_tasks) / len(lead_time_annotated_tasks)
 
                 items.append(("Average Annotation Time (In Seconds)" , round(avg_lead_time, 2)))
 


### PR DESCRIPTION
# Description

Calculate annotation time and word count for labeled tasks instead of accepted tasks if review mode is enabled for a project 

Related to [SN-427](https://project-sunbird.atlassian.net/browse/SN-427?atlOrigin=eyJpIjoiNDhhODYyZDY0MWI5NDA4NmE2ZTY1MzE0MWI3ZjdmYjkiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests / checks that you performed to verify your changes. Provide instructions so we can reproduce. Please delete options that are not relevant.

- [ ] Tested the API endpoint on Swagger with the 'Try it out' feature
- [ ] Tested the Models using the Django Shell
- [ ] Any other tests you performed for checking edge cases.
- [ ] Any other tests you performed for checking exceptions.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Checklist for Models

If you added new models / made changes to exsting models, please fill this checklist. 

- [ ] The primary key of the Model is an AutoField
- [ ] I have defined the `__str__` method for the Model
- [ ] If the field is optional, it has been spcified explicitly
- [ ] I have added a `verbose_name` for each Field.
- [ ] I have added a docstring for the Model
- [ ] The model is registered on Admin Site.
- [ ] I have pushed the migrations.

## Checklist for API

If you added new api endpoints / made changes to exsting endpoints, please fill this checklist. 

- [x] The endpoint is accessible through Swagger.
- [x] The endpoint supports permissions and authentication for different roles.
- [x] All exceptions have been handled and appropriate status code is returned to the user.
- [x] I have added docstrings for ViewSets / Serializers.
