### PR TITLE
fix: for `enable_task_reviews` word count and lead time should be shown for labeled tasks

### DIFF
--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -966,7 +966,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
 
                 if proj.enable_task_reviews:
-                    annotations = Annotation.objects.filter(completed_by=each_user,task__in=labeled_tasks)
+                    annotations = Annotation_model.objects.filter(completed_by=each_user,task__in=labeled_tasks)
                     lead_time_annotated_tasks = [annot.lead_time for annot in annotations]
                     avg_lead_time = 0
                     if len(lead_time_annotated_tasks) > 0 :

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -925,8 +925,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
                 proj = Project.objects.get(id = pk)
                 if proj.enable_task_reviews : 
-                    labeled_tasks  =Task.objects.filter(project_id=pk,annotation_users= each_user,task_status='labeled',\
-                        correct_annotation__created_at__range = [start_date, end_date])
+                    labeled_tasks  =Task.objects.filter(project_id=pk,annotation_users= each_user,task_status='labeled', annotations__created_at__range=[start_date, end_date])
                     labeled_tasks_count = labeled_tasks.count()
 
                     items.append(("Labeled Tasks" , labeled_tasks_count))

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -347,7 +347,6 @@ class AnalyticsViewSet(viewsets.ViewSet):
                 "Unlabeled Tasks" : all_pending_tasks_in_project,
                 "Skipped Tasks" : total_skipped_tasks,
                 "Draft Tasks" : all_draft_tasks_in_project,
-                
                 "Average Annotation Time (In Seconds)" : avg_lead_time
             }
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -347,13 +347,9 @@ class AnalyticsViewSet(viewsets.ViewSet):
                 "Unlabeled Tasks" : all_pending_tasks_in_project,
                 "Skipped Tasks" : total_skipped_tasks,
                 "Draft Tasks" : all_draft_tasks_in_project,
-                "Average Annotation Time (In Seconds)" : avg_lead_time
+                "Average Annotation Time (In Seconds)" : avg_lead_time,
+                "Annotated Tasks": task_count
             }
-
-            if proj.enable_task_reviews:
-                result["Labeled Tasks"] = task_count
-            else:
-                result["Annotated Tasks"] = task_count
 
             if is_translation_project:
                 result["Word Count"] = total_word_count

--- a/backend/workspaces/views.py
+++ b/backend/workspaces/views.py
@@ -301,13 +301,15 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
                     pass
                 no_of_annotators_assigned = len( [annotator for annotator in annotators_list if annotator not in owners ])
                 un_labeled_count = Task.objects.filter(project_id = proj.id,task_status = 'unlabeled').count()
-                labeled_count = Task.objects.filter(Q (project_id = proj.id) & Q(task_status = 'accepted') & Q (correct_annotation__created_at__range = [start_date, end_date])).count()
+                accepted_count = Task.objects.filter(Q (project_id = proj.id) & Q(task_status = 'accepted') & Q (correct_annotation__created_at__range = [start_date, end_date])).count()
                 skipped_count = Task.objects.filter(project_id = proj.id,task_status = 'skipped').count()
                 dropped_tasks = Task.objects.filter(project_id = proj.id,task_status = 'draft').count()
+                labeled_count = Task.objects.filter(project_id = proj.id,task_status = 'labeled').count()
+                
                 if total_tasks == 0:
                     project_progress = 0.0
                 else :
-                    project_progress = (labeled_count / total_tasks) * 100
+                    project_progress = (accepted_count / total_tasks) * 100
                 result = {
                     "Project Id" : project_id,
                     "Project Name" : project_name,
@@ -315,12 +317,13 @@ class WorkspaceCustomViewSet(viewsets.ViewSet):
                     "Project Type" : project_type,
                     "No .of Annotators Assigned" : no_of_annotators_assigned,
                     "Assigned Tasks" : total_tasks,
-                    "Annotated Tasks" : labeled_count,
+                    "Annotated Tasks" : accepted_count,
+                    "Labeled Tasks": labeled_count,
                     "Unlabeled Tasks" : un_labeled_count,
                     "Skipped Tasks": skipped_count,
                     "Draft Tasks" : dropped_tasks,
                     "Project Progress" : round(project_progress,3)
-                    }
+                }
                 final_result.append(result)
         ret_status = status.HTTP_200_OK
         return Response(final_result , status = ret_status )


### PR DESCRIPTION
# Description

fix: for `enable_task_reviews` word count and lead time should be shown for labeled tasks

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests / checks that you performed to verify your changes. Provide instructions so we can reproduce. Please delete options that are not relevant.

- [ ] Tested the API endpoint on Swagger with the 'Try it out' feature
- [ ] Tested the Models using the Django Shell
- [ ] Any other tests you performed for checking edge cases.
- [ ] Any other tests you performed for checking exceptions.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

## Checklist for Models

If you added new models / made changes to exsting models, please fill this checklist. 

- [ ] The primary key of the Model is an AutoField
- [ ] I have defined the `__str__` method for the Model
- [ ] If the field is optional, it has been spcified explicitly
- [ ] I have added a `verbose_name` for each Field.
- [ ] I have added a docstring for the Model
- [ ] The model is registered on Admin Site.
- [ ] I have pushed the migrations.

## Checklist for API

If you added new api endpoints / made changes to exsting endpoints, please fill this checklist. 

- [ ] The endpoint is accessible through Swagger.
- [ ] The endpoint supports permissions and authentication for different roles.
- [ ] All exceptions have been handled and appropriate status code is returned to the user.
- [ ] I have added docstrings for ViewSets / Serializers.
