### PR TITLE
Add Swagger Documentation to Celery Logging Endpoints

### DIFF
--- a/backend/dataset/views.py
+++ b/backend/dataset/views.py
@@ -370,8 +370,26 @@ class DatasetInstanceViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
+    @swagger_auto_schema(
+        method="get",
+        manual_parameters=[
+            openapi.Parameter(
+                "task_name",
+                openapi.IN_QUERY,
+                description=(
+                    f"A task name to filter the tasks by. Allowed Tasks: {ALLOWED_CELERY_TASKS}"
+                ),
+                type=openapi.TYPE_STRING,
+                required=True,
+            ),
+        ],
+        responses={
+            200: "Returns the past task run history for a particular dataset instance and task name"
+        },
+    )
     @action(methods=["GET"], detail=True, name="Get all past instances of celery tasks")
     def get_async_task_results(self, request, pk):
+        # sourcery skip: do-not-use-bare-except
         """
         View to get all past instances of celery tasks
         URL: /data/instances/<instance-id>/get_async_task_results?task_name=<task-name>

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1808,6 +1808,23 @@ class ProjectViewSet(viewsets.ModelViewSet):
     def language_choices(self, request):
         return Response(LANG_CHOICES)
 
+    @swagger_auto_schema(
+        method="get",
+        manual_parameters=[
+            openapi.Parameter(
+                "task_name",
+                openapi.IN_QUERY,
+                description=(
+                    f"A task name to filter the tasks by. Allowed Tasks: {ALLOWED_CELERY_TASKS}"
+                ),
+                type=openapi.TYPE_STRING,
+                required=True,
+            ),
+        ],
+        responses={
+            200: "Returns the past task run history for a particular dataset instance and task name"
+        },
+    )
     @action(methods=["GET"], detail=True, name="Get all past instances of celery tasks")
     def get_async_task_results(self, request, pk):
         """


### PR DESCRIPTION
# Description

This PR adds swagger manual documentation to celery logging endpoints to ensure that the API could be tested from Swagger. 

Fixes SN526
