### PR TITLE
periodical and cumulative analytics  apis added in org level

### DIFF
--- a/backend/organizations/views.py
+++ b/backend/organizations/views.py
@@ -586,8 +586,29 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             )
         project_type = request.data.get("project_type")
         periodical_type = request.data.get("periodical_type")
+
+        start_date = request.data.get("start_date")
+        end_date = request.data.get("end_date")
+
         org_created_date = organization.created_at
         present_date = datetime.now(timezone.utc)
+
+        if start_date != None:
+            date1 = start_date
+            org_created_date = datetime(
+                int(date1.split("-")[0]),
+                int(date1.split("-")[1]),
+                int(date1.split("-")[2]),
+                tzinfo=timezone(offset=timedelta()),
+            )
+        if end_date != None:
+            date2 = end_date
+            present_date = datetime(
+                int(date2.split("-")[0]),
+                int(date2.split("-")[1]),
+                int(date2.split("-")[2]),
+                tzinfo=timezone(offset=timedelta()),
+            )
 
         periodical_list = []
         if periodical_type == "weekly":

--- a/backend/organizations/views.py
+++ b/backend/organizations/views.py
@@ -552,8 +552,9 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         languages = list(set([proj.tgt_language for proj in proj_objs]))
         final_result = []
         for lang in languages:
+            proj_lang_filter = proj_objs.filter(tgt_language=lang)
             tasks_count = Task.objects.filter(
-                project_id__in=proj_objs,
+                project_id__in=proj_lang_filter,
                 project_id__tgt_language=lang,
                 task_status__in=[
                     "labeled",
@@ -658,10 +659,9 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
             data = []
             for lang in languages:
-
+                proj_lang_filter = proj_objs.filter(tgt_language=lang)
                 tasks_objs = Task.objects.filter(
-                    project_id__in=proj_objs,
-                    project_id__tgt_language=lang,
+                    project_id__in=proj_lang_filter,
                     task_status__in=[
                         "labeled",
                         "accepted",


### PR DESCRIPTION
# Description

API end points : 

1) http://localhost:8000/organizations/1/periodical_tasks_count/ 

body : 
--------
{
"project_type" : "ContextualTranslationEditing",
"periodical_type" : "weekly"  (we can select   "monthly" or "yearly" here)
}

2) http://localhost:8000/organizations/1/cumulative_tasks_count/

body 
---------
{
"project_type" : "ContextualTranslationEditing"
}


