### PR TITLE
added task status based de-allocation of tasks for annotator and revi…

### DIFF
--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -2,6 +2,7 @@ import re
 from collections import OrderedDict
 from datetime import datetime
 from time import sleep
+import ast
 
 from django.core.files import File
 from django.db.models import Count, Q
@@ -912,16 +913,25 @@ class ProjectViewSet(viewsets.ModelViewSet):
         """
         Unassigns all unlabeled tasks from an annotator.
         """
+
         user = request.user
+        if "task_status" in dict(request.query_params).keys():
+            task_status = request.query_params["task_status"]
+            task_status = ast.literal_eval(task_status)
+        else:
+            return Response(
+                {"message": "please provide the task_status to unassign tasks"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         userRole = user.role
         user_obj = User.objects.get(pk=user.id)
         project_id = pk
-
         if project_id:
             tasks = (
                 Task.objects.filter(project_id__exact=project_id)
                 .filter(annotation_users=user.id)
-                .filter(task_status=UNLABELED)
+                .filter(task_status__in=task_status)
             )
             if tasks.count() > 0:
                 for task in tasks:
@@ -1074,12 +1084,21 @@ class ProjectViewSet(viewsets.ModelViewSet):
         user = request.user
         project_id = pk
 
+        if "task_status" in dict(request.query_params).keys():
+            task_status = request.query_params["task_status"]
+            task_status = ast.literal_eval(task_status)
+        else:
+            return Response(
+                {"message": "please provide the task_status to unassign tasks"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         if project_id:
             project_obj = Project.objects.get(pk=project_id)
             if project_obj and user in project_obj.annotation_reviewers.all():
                 tasks = (
                     Task.objects.filter(project_id__exact=project_id)
-                    .filter(task_status=LABELED)
+                    .filter(task_status__in=task_status)
                     .filter(review_user=user.id)
                 )
                 if tasks.count() > 0:


### PR DESCRIPTION
…ewer

# Description


added functionality to de-allocate tasks for annotator and reviewer based on task_status  which we requested for .

## sample  api endpoints :

http://localhost:8000/projects/69/unassign_review_tasks/?task_status=['labeled','draft']

http://localhost:8000/projects/69/unassign_tasks/?task_status=['unlabeled','skipped','draft']
