### PR TITLE
allowed managers to deallocate review and annotation tasks

### DIFF
--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1108,8 +1108,22 @@ class ProjectViewSet(viewsets.ModelViewSet):
         """
         Unassigns all unlabeled tasks from an annotator.
         """
-
-        user = request.user
+        if "annotator_id" in dict(request.query_params).keys():
+            annotator_id = request.query_params["annotator_id"]
+            project = Project.objects.get(pk=pk)
+            annotator = User.objects.get(pk=annotator_id)
+            workspace = project.workspace_id
+            if request.user in workspace.managers.all():
+                user = annotator
+            else:
+                return Response(
+                    {
+                        "message": "Only workspace managers can unassign tasks from other annotators."
+                    },
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+        else:
+            user = request.user
         userRole = user.role
         user_obj = User.objects.get(pk=user.id)
         project_id = pk
@@ -1319,7 +1333,22 @@ class ProjectViewSet(viewsets.ModelViewSet):
         """
         Unassigns all labeled tasks from a reviewer.
         """
-        user = request.user
+        if "reviewer_id" in dict(request.query_params).keys():
+            reviewer_id = request.query_params["reviewer_id"]
+            reviewer = User.objects.get(pk=reviewer_id)
+            project = Project.objects.get(pk=pk)
+            workspace = project.workspace_id
+            if request.user in workspace.managers.all():
+                user = reviewer
+            else:
+                return Response(
+                    {
+                        "message": "Only workspace managers can unassign tasks from other reviewers"
+                    },
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+        else:
+            user = request.user
         project_id = pk
 
         if "review_status" in dict(request.query_params).keys():


### PR DESCRIPTION
Allow managers to deallocate annotators and reviewers tasks 

extra query parameter to add:
-reviewer_id for unassign_review_tasks endpoint.
- annotator_id for unassign_tasks endpoint.