### PR TITLE
Review reports modifications

### DIFF
--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -121,10 +121,32 @@ def get_review_reports(proj_id, userid, start_date, end_date):
     ).count()
     # minor_changes, major_changes = minor_major_accepted_task(acceptedwtchange_objs)
 
-    labeled_tasks = Task.objects.filter(
-        project_id=proj_id, review_user=userid, task_status="annotated"
-    )
-    labeled_tasks_count = labeled_tasks.count()
+    unreviewed = Annotation_model.objects.filter(
+        annotation_status="unreviewed",
+        task__project_id=proj_id,
+        task__review_user=userid,
+        parent_annotation_id__isnull=False,
+        created_at__range=[start_date, end_date],
+    ).count()
+    unreviewed_count = unreviewed.count()
+
+    draft = Annotation_model.objects.filter(
+        annotation_status="draft",
+        task__project_id=proj_id,
+        task__review_user=userid,
+        parent_annotation_id__isnull=False,
+        created_at__range=[start_date, end_date],
+    ).count()
+    draft_count = draft.count()
+
+    skipped = Annotation_model.objects.filter(
+        annotation_status="skipped",
+        task__project_id=proj_id,
+        task__review_user=userid,
+        parent_annotation_id__isnull=False,
+        created_at__range=[start_date, end_date],
+    ).count()
+    skipped_count = skipped.count()
 
     to_be_revised_tasks_count = Annotation_model.objects.filter(
         annotation_status="to_be_revised",
@@ -140,7 +162,9 @@ def get_review_reports(proj_id, userid, start_date, end_date):
         "Accepted": accepted_objs_count,
         "Accepted With Minor Changes": minor_changes,
         "Accepted With Major Changes": major_changes,
-        "Labeled": labeled_tasks_count,
+        "Un Reviewed": unreviewed_count,
+        "Draft": draft_count,
+        "Skipped": skipped_count,
         "To Be Revised": to_be_revised_tasks_count,
     }
     return result

--- a/backend/tasks/migrations/0034_auto_20230127_1221.py
+++ b/backend/tasks/migrations/0034_auto_20230127_1221.py
@@ -21,16 +21,21 @@ def change_existing_task_annotation_status_in_db(apps, schema_editor):
 
     # #create empty annotations for  unlabeled and skipped  pulled tasks .
 
-    # pulled_unlabeled_skipped_tasks = taskobj.filter(task_status__in = ["unlabeled", "skipped"],annotation_users__isnull = False)
+    pulled_unlabeled_skipped_tasks = taskobj.filter(
+        task_status__in=["unlabeled", "skipped"], annotation_users__isnull=False
+    )
 
-    # for tas in pulled_unlabeled_skipped_tasks:
-    #     for user1 in tas.annotation_users:
-    #         base_annotation_obj=Annotation(
-    #                     result=[],
-    #                     task=tas,
-    #                     completed_by=user1,
-    #                 )
-    #         base_annotation_obj.save()
+    pulled_tasks_list = []
+    for tas in tqdm(pulled_unlabeled_skipped_tasks):
+        for user1 in tas.annotation_users.all():
+            base_annotation_obj = Annotation(
+                result=[],
+                task=tas,
+                completed_by=user1,
+            )
+            pulled_tasks_list.append(base_annotation_obj)
+
+    Annotation.objects.bulk_create(pulled_tasks_list, 512)
 
     # annotator annotation objects status update
     annot1 = annotator_annotobj.filter(task__task_status__in=["unlabeled", "freezed"])

--- a/backend/tasks/migrations/0034_auto_20230127_1221.py
+++ b/backend/tasks/migrations/0034_auto_20230127_1221.py
@@ -18,6 +18,20 @@ def change_existing_task_annotation_status_in_db(apps, schema_editor):
     reviewer_annotobj = annotations.objects.using(db_alias).filter(
         parent_annotation_id__isnull=False
     )
+
+    # #create empty annotations for  unlabeled and skipped  pulled tasks .
+
+    # pulled_unlabeled_skipped_tasks = taskobj.filter(task_status__in = ["unlabeled", "skipped"],annotation_users__isnull = False)
+
+    # for tas in pulled_unlabeled_skipped_tasks:
+    #     for user1 in tas.annotation_users:
+    #         base_annotation_obj=Annotation(
+    #                     result=[],
+    #                     task=tas,
+    #                     completed_by=user1,
+    #                 )
+    #         base_annotation_obj.save()
+
     # annotator annotation objects status update
     annot1 = annotator_annotobj.filter(task__task_status__in=["unlabeled", "freezed"])
     ann1_list = []

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -143,6 +143,9 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
         page_number = None
         if "page" in dict(request.query_params):
             page_number = request.query_params["page"]
+        records = 10
+        if "records" in dict(request.query_param):
+            records = request.query_params["records"]
 
         if "project_id" in dict(request.query_params):
             proj_id = request.query_params["project_id"]
@@ -189,7 +192,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                                     request.GET, "data", list(tasks.first().data.keys())
                                 )
                             )
-                        ann_filter1 = ann.filter(task__in=tasks)
+                        ann_filter1 = ann.filter(task__in=tasks).order_by("-updated_at")
 
                         task_ids = [an.task_id for an in ann_filter1]
                         annotation_status = [an.annotation_status for an in ann_filter1]
@@ -203,7 +206,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                             tas["user_mail"] = user_mail[idx]
                             ordered_tasks.append(tas)
                         if page_number is not None:
-                            page_object = Paginator(ordered_tasks, 10)
+                            page_object = Paginator(ordered_tasks, records)
                             try:
                                 final_dict["total_count"] = len(ordered_tasks)
                                 page_items = page_object.page(page_number)
@@ -235,7 +238,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                             request.GET, "data", list(tasks.first().data.keys())
                         )
                     )
-                ann_filter1 = ann.filter(task__in=tasks)
+                ann_filter1 = ann.filter(task__in=tasks).order_by("-updated_at")
 
                 task_ids = [an.task_id for an in ann_filter1]
                 annotation_status = [an.annotation_status for an in ann_filter1]
@@ -251,7 +254,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                     ordered_tasks.append(tas)
 
                 if page_number is not None:
-                    page_object = Paginator(ordered_tasks, 10)
+                    page_object = Paginator(ordered_tasks, records)
 
                     try:
                         final_dict["total_count"] = len(ordered_tasks)
@@ -290,7 +293,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                                     request.GET, "data", list(tasks.first().data.keys())
                                 )
                             )
-                        ann_filter1 = ann.filter(task__in=tasks)
+                        ann_filter1 = ann.filter(task__in=tasks).order_by("-updated_at")
 
                         task_ids = [an.task_id for an in ann_filter1]
                         annotation_status = [an.annotation_status for an in ann_filter1]
@@ -305,7 +308,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                             ordered_tasks.append(tas)
 
                         if page_number is not None:
-                            page_object = Paginator(ordered_tasks, 10)
+                            page_object = Paginator(ordered_tasks, records)
 
                             try:
                                 final_dict["total_count"] = len(ordered_tasks)
@@ -338,7 +341,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                             request.GET, "data", list(tasks.first().data.keys())
                         )
                     )
-                ann_filter1 = ann.filter(task__in=tasks)
+                ann_filter1 = ann.filter(task__in=tasks).order_by("-updated_at")
 
                 task_ids = [an.task_id for an in ann_filter1]
                 annotation_status = [an.annotation_status for an in ann_filter1]
@@ -360,7 +363,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                     tas["annotator_mail"] = annotator_mail[idx]
                     ordered_tasks.append(tas)
                 if page_number is not None:
-                    page_object = Paginator(ordered_tasks, 10)
+                    page_object = Paginator(ordered_tasks, records)
 
                     try:
                         final_dict["total_count"] = len(ordered_tasks)
@@ -402,7 +405,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                     ordered_tasks = list(tasks.values())
                     final_dict = {}
                     if page_number is not None:
-                        page_object = Paginator(ordered_tasks, 10)
+                        page_object = Paginator(ordered_tasks, records)
 
                         try:
                             final_dict["total_count"] = len(ordered_tasks)
@@ -441,7 +444,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                 ordered_tasks = list(tasks.values())
                 final_dict = {}
                 if page_number is not None:
-                    page_object = Paginator(ordered_tasks, 10)
+                    page_object = Paginator(ordered_tasks, records)
 
                     try:
                         final_dict["total_count"] = len(ordered_tasks)
@@ -477,7 +480,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                 ordered_tasks = list(tasks.values())
                 final_dict = {}
                 if page_number is not None:
-                    page_object = Paginator(ordered_tasks, 10)
+                    page_object = Paginator(ordered_tasks, records)
 
                     try:
                         final_dict["total_count"] = len(ordered_tasks)


### PR DESCRIPTION
# Description

 Create Empty annotation for unlabeled, skipped tasks assigned to an annotator. (in migration file 0034).
- Add skipped, draft and unreviewed count in get_analytics project reports. (remove labeled task count).
- Sort tasks by updated_at annotation field in annotation tasks and review tasks tabs.