### PR TITLE
deduplicate dataset instance celery task

### DIFF
--- a/backend/dataset/tasks.py
+++ b/backend/dataset/tasks.py
@@ -5,6 +5,10 @@ from tablib import Dataset
 
 from .resources import RESOURCE_MAP
 
+from dataset.models import DatasetInstance
+from django.apps import apps
+from tasks.models import Task, Annotation
+
 #### CELERY SHARED TASKS
 
 
@@ -98,3 +102,66 @@ def upload_data_to_data_instance(
             },
         )
         raise Exception(f"Upload failed for lines: {failed_rows}")
+
+
+@shared_task(bind=True)
+def deduplicate_dataset_instance_items(self, pk, deduplicate_field_list):
+    if len(deduplicate_field_list) == 0:
+        return "Field list cannot be empty"
+    try:
+        dataset_instance = DatasetInstance.objects.get(pk=pk)
+    except Exception as error:
+        return error
+    dataset_type = dataset_instance.dataset_type
+    dataset_model = apps.get_model("dataset", dataset_type)
+    dataset_items = dataset_model.objects.filter(instance_id=dataset_instance)
+    duplicate_data_tracking_dict = {}
+    tasks_count = 0
+    annotations_count = 0
+    dataset_items_count = 0
+    for dataset_item in dataset_items:
+        dataset_item_field_value = []
+        for field in deduplicate_field_list:
+            dataset_item_field_value.append(getattr(dataset_item, field))
+        dict_key = tuple(dataset_item_field_value)
+        if dict_key not in duplicate_data_tracking_dict:
+            related_tasks = Task.objects.filter(input_data__id=dataset_item.id)
+            related_tasks_ids = [task.id for task in related_tasks]
+            related_annos = Annotation.objects.filter(
+                task__id__in=related_tasks_ids
+            ).order_by("-id")
+            duplicate_data_tracking_dict[dict_key] = [
+                related_annos,
+                dataset_item,
+                len(related_tasks_ids),
+            ]
+        else:
+            print(duplicate_data_tracking_dict[dict_key])
+            related_tasks = Task.objects.filter(input_data=dataset_item.id)
+            related_tasks_ids = [task.id for task in related_tasks]
+            related_annos1 = Annotation.objects.filter(
+                task__id__in=related_tasks_ids
+            ).order_by("-id")
+            related_annos2 = duplicate_data_tracking_dict[dict_key][0]
+            if related_annos1.count() <= related_annos2.count():
+                annotations_count += related_annos1.count()
+                tasks_count += len(related_tasks_ids)
+                for anno in related_annos1:
+                    anno.delete()
+                dataset_item.delete()
+                dataset_items_count += 1
+            else:
+                dataset_item2 = duplicate_data_tracking_dict[dict_key][1]
+                annotations_count += related_annos2.count()
+                tasks_count += duplicate_data_tracking_dict[dict_key][2]
+                for anno in related_annos2:
+                    anno.delete()
+                dataset_item2.delete()
+                dataset_items_count += 1
+                duplicate_data_tracking_dict[dict_key] = [
+                    related_annos1,
+                    dataset_item,
+                    len(related_tasks_ids),
+                ]
+
+    return f"Deleted {dataset_items_count} duplicate dataset items and {tasks_count} related tasks and {annotations_count} related annotations"

--- a/backend/dataset/views.py
+++ b/backend/dataset/views.py
@@ -29,7 +29,7 @@ from users.models import User
 from . import resources
 from .models import *
 from .serializers import *
-from .tasks import upload_data_to_data_instance
+from .tasks import upload_data_to_data_instance, deduplicate_dataset_instance_items
 import dataset
 from tasks.models import Task, Annotation
 
@@ -727,6 +727,47 @@ class DatasetInstanceViewSet(viewsets.ModelViewSet):
     @action(methods=["GET"], detail=False, name="List all Accepted Upload Filetypes")
     def accepted_filetypes(self, request):
         return Response(DatasetInstanceViewSet.ACCEPTED_FILETYPES)
+
+    @swagger_auto_schema(
+        method="get",
+        manual_parameters=[
+            openapi.Parameter(
+                "deduplicate_fields_list",
+                openapi.IN_QUERY,
+                description=(
+                    "A list of fields based on which dataset items need to be deduplicated"
+                ),
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Items(type=openapi.TYPE_STRING),
+                required=True,
+            )
+        ],
+        responses={200: "Duplicate removal started"},
+    )
+    @action(
+        methods=["GET"],
+        detail=True,
+        url_path="remove_duplicates_from_dataset_instance",
+        url_name="remove_duplicates_from_dataset_instance",
+    )
+    def remove_duplicates(self, request, pk=None):
+        try:
+            deduplicate_fields_list = request.query_params["deduplicate_fields_list"]
+        except:
+            return Response(
+                {"message": "deduplicate_fields_list is a required query parameter"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        deduplicate_fields_list = deduplicate_fields_list.split(",")
+        if len(deduplicate_fields_list) == 0:
+            return Response(
+                {"message": "Fields list cannot be empty."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        deduplicate_dataset_instance_items.delay(pk, deduplicate_fields_list)
+        ret_dict = {"message": "Duplicate removal started"}
+        ret_status = status.HTTP_200_OK
+        return Response(ret_dict, status=ret_status)
 
 
 class DatasetItemsViewSet(viewsets.ModelViewSet):

--- a/backend/projects/tasks.py
+++ b/backend/projects/tasks.py
@@ -369,7 +369,9 @@ def export_project_in_place(
                         )
                     setattr(data_item, field, conversation_json)
                 elif field == "domain":
-                    setattr(data_item, field, json.loads(ta[field])[0]["taxonomy"][0][0])
+                    setattr(
+                        data_item, field, json.loads(ta[field])[0]["taxonomy"][0][0]
+                    )
                 else:
                     setattr(data_item, field, ta[field])
             data_items.append(data_item)

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -416,7 +416,7 @@ def convert_annotation_result_to_formatted_json(annotation_result, speakers_json
                         if speaker["name"] == labels_dict["value"]["labels"][0]
                     )["speaker_id"]
                 except KeyError:
-                    formatted_result_dict["speaker_id"]=None
+                    formatted_result_dict["speaker_id"] = None
                 formatted_result_dict["start"] = labels_dict["value"]["start"]
                 formatted_result_dict["end"] = labels_dict["value"]["end"]
 

--- a/backend/shoonya_backend/settings.py
+++ b/backend/shoonya_backend/settings.py
@@ -37,7 +37,11 @@ DEBUG = os.getenv("ENV") == "dev"
 if DEBUG:
     ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "*"]
 else:
-    ALLOWED_HOSTS = ["shoonya.ai4bharat.org", "0.0.0.0", "backend.shoonya.ai4bharat.org"]
+    ALLOWED_HOSTS = [
+        "shoonya.ai4bharat.org",
+        "0.0.0.0",
+        "backend.shoonya.ai4bharat.org",
+    ]
 
 # Application definition
 


### PR DESCRIPTION
Currently duplicate record check is being done only on the file to be uploaded. This has to be modified to also check if the record is already present in the dataset.  

-create a new endpoint.

-This endpoint will be hit after data is uploaded to dataset_instance with dataset_instance id and list of fields for which we want an unique tuple. 

-This endpoint will check for the duplicate dataset_item, one having highest no of  annotation linked will be kept, and other will be deleted along with linked_tasks and annotations.

Refer swagger docs for detailed docs.