### PR TITLE
New endpoint to retrieve task details for confirmation before deletion

### DIFF
--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -1042,7 +1042,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                 project_task_ids = request.data.get("project_task_ids")
                 if len(project_task_ids) == 0:
                     return JsonResponse(
-                        {"message": "Please enter valid values"},
+                        {"message": "No task Ids found in request"},
                         status=status.HTTP_400_BAD_REQUEST,
                     )
             else:
@@ -1056,7 +1056,7 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
                     or project_task_end_id == None
                 ):
                     return JsonResponse(
-                        {"message": "Please enter valid values"},
+                        {"message": "Project task start id or end id not found."},
                         status=status.HTTP_400_BAD_REQUEST,
                     )
 
@@ -1078,13 +1078,16 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
 
             if num_project_tasks == 0:
                 return JsonResponse(
-                    {"message": "No rows to show"}, status=status.HTTP_200_OK
+                    {
+                        "message": "No rows to show corresponding to the entered task ids"
+                    },
+                    status=status.HTTP_200_OK,
                 )
             else:
                 serializer = TaskSerializer(result_page, many=True)
                 return paginator.get_paginated_response(
                     {
-                        "message": "Project tasks retrieved successfully",
+                        "message": "Project tasks retrieved successfully for valid task ids",
                         "data": serializer.data,
                     }
                 )

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -993,6 +993,90 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
+                "project_task_start_id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                "project_task_end_id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                "project_task_ids": openapi.Schema(
+                    type=openapi.TYPE_ARRAY,
+                    items=openapi.Items(type=openapi.TYPE_INTEGER),
+                ),
+            },
+            description="Either pass the project_task_start_id and project_task_end_id or the project_task_ids in request body",
+        ),
+        manual_parameters=[
+            openapi.Parameter(
+                "id",
+                openapi.IN_PATH,
+                description=("A unique integer identifying the project"),
+                type=openapi.TYPE_INTEGER,
+                required=True,
+            )
+        ],
+        responses={
+            200: "returned successfully! or No rows to show",
+            403: "Not authorized!",
+            400: "Invalid parameters in the request body!",
+        },
+    )
+    @action(
+        detail=True,
+        methods=["POST"],
+        url_path="get_all_tasks_for_confirmation_before_deletion",
+        url_name="get_all_tasks_for_confirmation_before_deletion",
+    )
+    def get_all_tasks_for_confirmation_before_deletion(self, request, pk=None):
+        project = Project.objects.get(pk=pk)
+        try:
+            if not (
+                    (request.user.role == User.ORGANIZATION_OWNER or request.user.is_superuser)
+                    and (request.user.organization == project.organization_id)
+            ):
+                return JsonResponse({"message": "You are not authorized to access the endpoint."}, status=status.HTTP_403_FORBIDDEN)
+
+
+
+            if "project_task_ids" in request.data:
+                project_task_ids = request.data.get("project_task_ids")
+                if len(project_task_ids) == 0:
+                    return JsonResponse({"message": "Please enter valid values"}, status=status.HTTP_400_BAD_REQUEST)
+            else:
+                project_task_start_id = request.data.get("project_task_start_id")
+                project_task_end_id = request.data.get("project_task_end_id")
+    
+                if (
+                    project_task_start_id == ""
+                    or project_task_end_id == ""
+                    or project_task_start_id == None
+                    or project_task_end_id == None
+                ):
+                    return JsonResponse({"message": "Please enter valid values"}, status=status.HTTP_400_BAD_REQUEST)
+
+    
+                project_task_ids = [
+                    id for id in range(project_task_start_id, project_task_end_id + 1)
+                ]
+    
+            project_tasks = Task.objects.filter(project_id=project).filter(
+                id__in=project_task_ids
+            )
+    
+            num_project_tasks = len(project_tasks)
+
+
+            if num_project_tasks == 0:
+                return JsonResponse({"message": "No rows to show"}, status=status.HTTP_200_OK)
+            else:
+                serializer = TaskSerializer(project_tasks, many=True)
+                return JsonResponse({"message": "Project tasks retrieved successfully","data": serializer.data,},status=status.HTTP_200_OK,)
+
+        except Exception as error:
+            return JsonResponse({"message":str(error) }, status=status.HTTP_400_BAD_REQUEST)
+
+
+    @swagger_auto_schema(
+        method="post",
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
                 "user_id": openapi.Schema(type=openapi.TYPE_INTEGER),
                 "task_type": openapi.Schema(type=openapi.TYPE_STRING),
             },
@@ -2042,90 +2126,4 @@ def get_celery_tasks(request):
 
     return JsonResponse(filtered_tasks, safe=False)
 
-@api_view(["GET"])
-def delete_project_tasks(request, pk=None):
-    project = Project.objects.get(pk=pk)
-    try:
-        if not (
-                (
-                        request.user.role == User.ORGANIZATION_OWNER
-                        or request.user.is_superuser
-                )
-                and (request.user.organization == project.organization_id)
-        ):
-            return Response(
-                {
-                    "status": status.HTTP_403_FORBIDDEN,
-                    "message": "You are not authorized to access the endpoint.",
-                }
-            )
 
-        if "project_task_ids" in request.data:
-            project_task_ids = request.data.get("project_task_ids")
-            if len(project_task_ids) == 0:
-                return Response(
-                    {
-                        "status": status.HTTP_400_BAD_REQUEST,
-                        "message": "Please enter valid values",
-                    }
-                )
-        else:
-            project_task_start_id = request.data.get("project_task_start_id")
-            project_task_end_id = request.data.get("project_task_end_id")
-
-            if (
-                project_task_start_id == ""
-                or project_task_end_id == ""
-                or project_task_start_id == None
-                or project_task_end_id == None
-            ):
-                return Response(
-                    {
-                        "status": status.HTTP_400_BAD_REQUEST,
-                        "message": "Please enter valid values",
-                    }
-                )
-
-            project_task_ids = [
-                id for id in range(project_task_start_id, project_task_end_id + 1)
-            ]
-
-        project_tasks = Task.objects.filter(project_id=project).filter(
-            id__in=project_task_ids
-        )
-
-        related_annotation_task_ids = [
-            project_task.id for project_task in project_tasks
-        ]
-        related_annotations = Annotation.objects.filter(
-            task__id__in=related_annotation_task_ids
-        ).order_by("-id")
-
-        num_project_tasks = len(project_tasks)
-        num_related_annotations = len(related_annotations)
-
-        if num_project_tasks == 0:
-            return Response(
-                {
-                    "status": status.HTTP_200_OK,
-                    "message": "No rows to show",
-                }
-            )
-
-        # for related_annotation in related_annotations:
-        #     related_annotation.delete()
-        # project_tasks.delete()
-        # return Response(
-        #     {
-        #         "status": status.HTTP_200_OK,
-        #         "message": f"Deleted {num_project_tasks} project tasks and {num_related_annotations} related annotations successfully!",
-        #     }
-        # )
-
-    except Exception as error:
-        return Response(
-            {
-                "status": status.HTTP_400_BAD_REQUEST,
-                "message": str(error),
-            }
-        )


### PR DESCRIPTION
# Description

- Added a new endpoint `get_all_tasks_for_confirmation_before_deletion` in the Task viewset in `tasks/views.py`
- This endpoint takes the input in a similar format as that of `delete_project_tasks` which is present in the same viewset
- Returns a paginated response that includes all the fields from the Task model for the all the task ids mentioned in the request

## Expected workflow
- `get_all_tasks_for_confirmation_before_deletion` endpoint will be called from the frontend instead of the `delete_project_tasks` endpoint first
- The user would be shown the results in form of a table
- When the user confirms then the `delete_project_tasks` would be called and the existing worflow would be followed
