### PR TITLE
swagger hotfix, removed faulty configs for an endpoint in tasks

### DIFF
--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -1202,14 +1202,6 @@ class TaskViewSet(viewsets.ModelViewSet, mixins.ListModelMixin):
 
     @swagger_auto_schema(
         method="get",
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={
-                "user_id": openapi.Schema(type=openapi.TYPE_INTEGER),
-                "task_type": openapi.Schema(type=openapi.TYPE_STRING),
-            },
-            required=["user_id"],
-        ),
         manual_parameters=[
             openapi.Parameter(
                 "user_id",


### PR DESCRIPTION
Swagger configs for one of the get endpoints had mentioned about request body which was causing an error in swagger, removed the faulty configs.