### PR TITLE
fix: ocr analytics mismatch - exclude rejected tasks, array truncation, removed nltk for ocr

### DIFF
--- a/backend/projects/utils.py
+++ b/backend/projects/utils.py
@@ -265,12 +265,15 @@ def calculate_word_error_rate_between_two_audio_transcription_annotation(
 
 
 def ocr_word_count(annotation_result):
+    import re
     word_count = 0
 
     for result in annotation_result:
         if result["type"] == "textarea":
             try:
-                word_count += no_of_words(result["value"]["text"][0])
+                for text_element in result["value"]["text"]:
+                    if text_element:
+                        word_count += len(re.split(r'\s+', text_element))
             except:
                 pass
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1248,8 +1248,9 @@ class AnalyticsViewSet(viewsets.ViewSet):
                 {"message": invalid_message}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        start_date = datetime.strptime(start_date, "%Y-%m-%d %H:%M")
-        end_date = datetime.strptime(end_date, "%Y-%m-%d %H:%M")
+        from datetime import timezone
+        start_date = datetime.strptime(start_date, "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
+        end_date = datetime.strptime(end_date, "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
 
         if start_date > end_date:
             return Response(
@@ -1335,7 +1336,7 @@ class AnalyticsViewSet(viewsets.ViewSet):
                     annotation_type=REVIEWER_ANNOTATION,
                     updated_at__range=[start_date, end_date],
                     completed_by=user_id,
-                ).exclude(annotation_status__in=["to_be_revised", "draft", "skipped"])
+                ).filter(annotation_status__in=['accepted', 'accepted_with_minor_changes', 'accepted_with_major_changes'])
             elif supercheck_reports:
                 labeld_tasks_objs = Task.objects.filter(
                     Q(project_id=proj.id)


### PR DESCRIPTION
## Description
This PR resolves a major discrepancy between the Shoonya Website's User Analytics dashboard and the Airflow Daily Email Reports. Previously, the website analytics were falsely inflating word counts for reviewers

This PR addresses four distinct bugs in the analytics and word count calculation pipelines:

### 1. Filtered Out "Rejected" Tasks (Global)
* **Bug:** The `/users/user_analytics/` API failed to exclude tasks marked as `rejected` by the reviewer, causing rejected words to inadvertently count toward their progress.
* **Fix:** Added strict filters on `REVIEWER_ANNOTATION` queries to only count tasks with statuses `accepted`, `accepted_with_minor_changes`, or `accepted_with_major_changes`.

### 2. Fixed Array Truncation Bug (OCR Projects)
* **Bug:** In `projects/utils.py`, `ocr_word_count()` was hardcoded to `result["value"]["text"][0]`. If a textarea contained multiple paragraphs (saved as an array), it only counted the very first paragraph and completely dropped the rest.
* **Fix:** Updated the logic to loop through all `text_element`s in the array.

### 3. Fixed NLTK 1-Character Tokenizer Bug (OCR Projects)
* **Bug:** The word counter relied on an NLTK tokenizer that explicitly dropped any word that was exactly 1 character long (e.g., "I", "a", "1", and single-character Indic graphemes).
* **Fix:** Replaced the NLTK tokenizer with a standard regex split (`re.split(r'\s+', text_element)`) inline for `ocr_word_count()` to ensure all words are properly counted. *(Note: The original `no_of_words` function was left intact for backward compatibility with other project types).*

### 4. Timezone Misalignment Fix
* **Bug:** The website converted frontend requests into local time (IST), whereas the Airflow DAG explicitly bounds queries using UTC.
* **Fix:** Enforced `.replace(tzinfo=timezone.utc)` on `start_date` and `end_date` within the `AnalyticsViewSet` to strictly align query boundaries.

## Testing
- [x] Ran a local simulation for user `4469` on `2026-08-04`.
- [x] Verified that the local API word count (3232) now perfectly matches the Airflow DAG email report (3232) instead of the previous inflated value (3757).
