### PR TITLE
fix: remove central.log to prevent OOM downtime

### DIFF
--- a/backend/loging/tasks.py
+++ b/backend/loging/tasks.py
@@ -72,41 +72,33 @@ def retrieve_logs_and_send_through_email(start_date_str, end_date_str, user_emai
         )
 
         if not start_date_str and not end_date_str:
-            central_blob_client = container_client.get_blob_client("central.log")
-            if central_blob_client.exists():
-                log_content = (
-                    central_blob_client.download_blob().readall().decode("utf-8")
-                )
-                log_content = log_content.replace("][", ",")
-                file_name = "central_logs.txt"
-            else:
-                raise Exception("Central log data not found")
+            start_date = datetime.min
+            end_date = datetime.max
+            file_name = "central_logs.txt"
         else:
             try:
                 start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
                 end_date = datetime.strptime(end_date_str, "%Y-%m-%d")
             except ValueError:
                 raise Exception("Invalid date format. Please use 'YYYY-MM-DD'.")
-            log_content = ""
-            for blob in container_client.list_blobs():
+            file_name = f"{start_date_str}_to_{end_date_str}_logs.txt"
+
+        log_content = ""
+        for blob in container_client.list_blobs():
+            try:
+                blob_date = datetime.strptime(blob.name.split(".")[0], "%Y-%m-%d")
+            except ValueError:
+                # Skip non-date-named blobs (e.g. leftover "central.log" or "temp_*" export files)
+                continue
+            if start_date <= blob_date <= end_date:
                 blob_client = container_client.get_blob_client(blob.name)
                 content = blob_client.download_blob().readall()
-                try:
-                    blob_date = datetime.strptime(blob.name.split(".")[0], "%Y-%m-%d")
-                    if start_date <= blob_date <= end_date:
-                        log_content += content.decode("utf-8")
-                except Exception as e:
-                    print(
-                        f"Failed to aggregate the logs between given dates : {str(e)}"
-                    )
-                    raise e
+                log_content += content.decode("utf-8")
 
-            if log_content == "":
-                raise Exception("No logs found")
+        if log_content == "":
+            raise Exception("No logs found")
 
-            log_content = log_content.replace("][", ",")
-
-            file_name = f"{start_date_str}_to_{end_date_str}_logs.txt"
+        log_content = log_content.replace("][", ",")
 
         file_name_with_prefix = f"temp_{file_name}"
 

--- a/backend/loging/views.py
+++ b/backend/loging/views.py
@@ -81,23 +81,6 @@ class TransliterationSelectionViewSet(APIView):
 
                 create_empty_log_for_next_day(container_client)
 
-                central_blob_client = container_client.get_blob_client("central.log")
-
-                if not central_blob_client.exists():
-                    central_blob_client.upload_blob("[]", overwrite=True)
-
-                central_existing_data = central_blob_client.download_blob()
-                central_existing_content = central_existing_data.readall().decode(
-                    "utf-8"
-                )
-                central_existing_json_data = json.loads(central_existing_content)
-                central_existing_json_data.append(data)
-
-                central_updated_content = json.dumps(
-                    central_existing_json_data, cls=CustomJSONEncoder
-                )
-                central_blob_client.upload_blob(central_updated_content, overwrite=True)
-
                 return Response(
                     {"message": "Data stored in Azure Blob successfully"},
                     status=status.HTTP_201_CREATED,


### PR DESCRIPTION
##  Description
This PR addresses a critical Out of Memory (OOM) downtime issue caused by the continuous growth and loading of the central.log file in Azure Blob Storage. 

The central.log was previously being downloaded and loaded entirely into memory, which scaled poorly over time as logging accumulated, eventually causing the service to crash. This PR completely removes the central.log dependency.

### Changes Made
- **Removed central.log read/write**: The application no longer attempts to append to or parse the singular central.log file.
- **Optimized Log Aggregation**: When querying logs without a specified start/end date, the system now sets start_date and end_date to system min and max. It iterates directly through the daily date-based blob logs (e.g., 2026-08-12.log), streaming only the matching content.
- **Improved Fault Tolerance**: Non-date-named blobs (like leftovers or temporary export files) are safely caught and skipped via a try/except block during aggregation to prevent unexpected parsing failures.
