### PR TITLE
fix: update batching logic to check capacity of latest project and set languages explicitly

### DIFF
--- a/backend/dataset/pipeline_utils.py
+++ b/backend/dataset/pipeline_utils.py
@@ -277,12 +277,20 @@ def build_project_title(language, part, row_type, batch_number):
     return f"JT-{part_token}-{language}-[{row_type}]-[B{batch_number}]"
 
 
-def get_next_batch_number(dataset_instance, language, part, row_type):
-    """Queries existing Project titles matching this dataset/type/part's pattern
-    *for this specific dataset instance* and returns the next batch number
-    (max existing + 1). Scoped to dataset_instance so that a separate
-    dataset created for the same language doesn't get treated as a
-    continuation of another dataset's batch sequence.
+def get_latest_project_for_group(dataset_instance, language, part, row_type):
+    """Returns (latest_project_or_None, next_batch_number) for this dataset
+    instance's (language, part, row_type) group.
+
+    Used to decide whether a new batch should wait for the task-limit
+    threshold: any project created via the threshold-met path always has
+    exactly `limit` tasks by construction (see create_projects_for_dataset_
+    category), so the *only* way an existing project can be under capacity
+    is if it was created as the very first batch for its group with fewer
+    than `limit` tasks available at the time. So "is there an existing
+    under-capacity project to fill first" is the right question -- not
+    "is this batch number 1" -- since once every existing project for a
+    group is already full, the next batch should be created immediately
+    just like a first-ever one would be, regardless of its count.
     """
     from projects.models import Project
 
@@ -290,14 +298,16 @@ def get_next_batch_number(dataset_instance, language, part, row_type):
     prefix = f"JT-{part_token}-{language}-[{row_type}]-[B"
     pattern = re.compile(re.escape(prefix) + r"(\d+)\]$")
 
+    latest_project = None
     max_batch = 0
-    for title in Project.objects.filter(
+    for project in Project.objects.filter(
         dataset_id=dataset_instance, title__startswith=prefix
-    ).values_list("title", flat=True):
-        match = pattern.match(title)
-        if match:
-            max_batch = max(max_batch, int(match.group(1)))
-    return max_batch + 1
+    ):
+        match = pattern.match(project.title)
+        if match and int(match.group(1)) > max_batch:
+            max_batch = int(match.group(1))
+            latest_project = project
+    return latest_project, max_batch + 1
 
 
 def build_unassigned_filter_string(domain, last_assigned_id):

--- a/backend/dataset/tasks.py
+++ b/backend/dataset/tasks.py
@@ -18,7 +18,7 @@ from .pipeline_utils import (
     build_target_object_key,
     build_unassigned_filter_string,
     get_audio_folder_name,
-    get_next_batch_number,
+    get_latest_project_for_group,
     get_project_config_for_language,
     get_row_part,
     get_row_type,
@@ -517,34 +517,32 @@ def create_projects_for_dataset_category(
         if unassigned_count == 0:
             continue
 
-        next_batch_number = get_next_batch_number(dataset_instance, language, part, category)
-        is_first_project_for_group = next_batch_number == 1
+        latest_project, next_batch_number = get_latest_project_for_group(
+            dataset_instance, language, part, category
+        )
+        latest_project_under_capacity = (
+            latest_project is not None
+            and Task.objects.filter(project_id=latest_project).count() < limit
+        )
 
-        # The very first project for a (language, part, category) group is
-        # created immediately regardless of count. Later batches only get
-        # created once a full batch's worth of unassigned tasks has piled
-        # up; until then, the existing under-capacity project is surfaced
-        # so a data lead can manually pull more tasks into it.
-        if not is_first_project_for_group and unassigned_count < limit:
-            existing_title = build_project_title(
-                language, part, category, next_batch_number - 1
-            )
-            existing_project_id = (
-                Project.objects.filter(dataset_id=dataset_instance, title=existing_title)
-                .values_list("id", flat=True)
-                .first()
-            )
+        # A new batch is created immediately once every existing project for
+        # this group is already full (or there's no project yet at all) --
+        # regardless of count, same as a first-ever batch. It only waits when
+        # the most recent existing project is itself under capacity, since
+        # that's the one that should be topped up first rather than leaving
+        # two partially-filled projects side by side.
+        if latest_project_under_capacity and unassigned_count < limit:
             skipped_groups.append(
                 {
                     "domain": domain,
                     "unassigned_count": unassigned_count,
                     "limit": limit,
-                    "existing_project_id": existing_project_id,
-                    "existing_project_title": existing_title,
+                    "existing_project_id": latest_project.id,
+                    "existing_project_title": latest_project.title,
                     "message": (
                         f"{unassigned_count} unassigned task(s) available - pull them "
-                        f"into '{existing_title}' via its 'Pull New Data Items' action, "
-                        f"or wait for more uploads to auto-create the next batch."
+                        f"into '{latest_project.title}' via its 'Pull New Data Items' "
+                        f"action, or wait for more uploads to auto-create the next batch."
                     ),
                 }
             )
@@ -568,6 +566,13 @@ def create_projects_for_dataset_category(
             sampling_parameters_json=sampling_parameters,
             filter_string=filter_string,
             project_stage=REVIEW_STAGE,
+            # Transcription, not translation -- src/tgt are both the
+            # dataset's own language. Set explicitly since this pipeline
+            # builds the Project directly via the ORM, bypassing
+            # ProjectSerializer (which is what normally saves these when a
+            # project is created through the standard UI form).
+            src_language=language,
+            tgt_language=language,
             metadata_json={
                 "acoustic_enabled_stage": project_config["acoustic_enabled_stage"],
                 "automatic_annotation_creation_mode": "annotation",

--- a/backend/dataset/views.py
+++ b/backend/dataset/views.py
@@ -516,6 +516,43 @@ class DatasetInstanceViewSet(viewsets.ModelViewSet):
         existing_instance_id = request.POST.get("existing_instance_id") or None
         deduplicate = request.POST.get("deduplicate", "false").lower() == "true"
 
+        # If adding to an existing dataset, the new CSV's language must match
+        # what's already in it -- each dataset is meant to hold a single
+        # language, and mixing languages would corrupt that invariant for
+        # every downstream domain/batch grouping. Checked here, synchronously,
+        # so the user gets immediate feedback instead of the async pipeline
+        # failing partway through (after audio has already been uploaded).
+        if existing_instance_id:
+            rows, fieldnames = parse_input_csv(csv_string)
+            validation = validate_input_csv(rows, fieldnames)
+            if validation["valid"] and validation["languages"]:
+                new_language = validation["languages"][0]
+                try:
+                    dataset_instance = DatasetInstance.objects.get(pk=existing_instance_id)
+                except DatasetInstance.DoesNotExist:
+                    return Response(
+                        {"message": "Dataset instance not found."},
+                        status=status.HTTP_404_NOT_FOUND,
+                    )
+                SpeechConversation = apps.get_model("dataset", "SpeechConversation")
+                existing_language = (
+                    SpeechConversation.objects.filter(instance_id=dataset_instance)
+                    .exclude(language="")
+                    .values_list("language", flat=True)
+                    .first()
+                )
+                if existing_language and existing_language != new_language:
+                    return Response(
+                        {
+                            "message": (
+                                f"Language mismatch: dataset '{dataset_instance.instance_name}' "
+                                f"already contains '{existing_language}' data, but this CSV is "
+                                f"'{new_language}'. Each dataset must contain a single language."
+                            )
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
         # Organisation is fixed to AI4Bharat (id=1) for this pipeline.
         config = {
             "dataset_name": request.POST.get("dataset_name"),


### PR DESCRIPTION
## Description
This PR introduces critical stability and validation improvements to the automated Dataset and Project creation pipeline, ensuring robust batching and preventing data corruption from mixed-language datasets.

### Key Changes
- **Synchronous Language Validation (`428d69fe`)**: Added an immediate, synchronous check when a user attempts to upload new data to an *existing* dataset instance. It ensures that the language in the uploaded CSV matches the language already present in the dataset. This prevents mixed-language datasets from corrupting downstream project batching and provides the user with immediate feedback before any async processing begins.
- **Improved Project Batching Logic (`a5e258dd`)**: 
  - Refactored the batching logic to evaluate the capacity of the *latest* existing project for a given group, rather than only checking if it's the very first project. This ensures that new tasks are correctly batched or surfaced for manual pulling into the most recent under-capacity project.
  - Explicitly set `src_language` and `tgt_language` to the dataset's language when automatically instantiating `Project` objects (since this ORM path bypasses the standard `ProjectSerializer`).

### Motivation and Context
As we move towards a fully automated end-to-end pipeline, strict invariants (like a single language per dataset) must be enforced early to prevent silent failures later in the pipeline. Furthermore, the previous batching logic could leave multiple partially filled projects side-by-side; the updated logic ensures we properly top up the latest under-capacity project before opening a new batch.