### PR TITLE
feat(dataset): add language validation and auto top-up support for pipeline

### DIFF
--- a/backend/dataset/tasks.py
+++ b/backend/dataset/tasks.py
@@ -1,4 +1,5 @@
 import io
+import json
 import os
 from base64 import b64decode
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -390,6 +391,8 @@ def create_dataset_and_project_pipeline(self, input_csv_string, config):
         },
     )
 
+    SpeechConversation = apps.get_model("dataset", "SpeechConversation")
+
     # Skip rows whose audio_url is already present in this dataset instance
     # (e.g. re-uploading the same CSV) -- but only when the user asked for
     # it via "Delete Duplicate Records". `remove_duplicates()` inside
@@ -398,19 +401,51 @@ def create_dataset_and_project_pipeline(self, input_csv_string, config):
     # upload, so that check has to happen here instead.
     duplicate_rows = []
     if deduplicate:
-        SpeechConversation = apps.get_model("dataset", "SpeechConversation")
-        existing_audio_urls = set(
+        # Starts with what's already in the dataset, then grows as rows are
+        # kept -- catches duplicates against the existing dataset AND
+        # duplicates within this same CSV batch (two rows sharing an
+        # audio_url), keeping only the first occurrence of each.
+        seen_audio_urls = set(
             SpeechConversation.objects.filter(instance_id=dataset_instance).values_list(
                 "audio_url", flat=True
             )
         )
         deduped_rows = []
         for row in shoonya_rows:
-            if row["audio_url"] in existing_audio_urls:
+            if row["audio_url"] in seen_audio_urls:
                 duplicate_rows.append({"audio_url": row["audio_url"]})
             else:
                 deduped_rows.append(row)
+                seen_audio_urls.add(row["audio_url"])
         shoonya_rows = deduped_rows
+
+    # Tag each row actually being inserted with a per-dataset sequence_id
+    # (1, 2, 3, ...), continuing from the highest sequence_id already used
+    # in this dataset instance across all previous uploads -- e.g. 12
+    # entries uploaded first get 1-12, then 10 more uploaded later get
+    # 13-22. Assigned after dedup so skipped duplicates don't consume a
+    # number. Rows preserve their upload/CSV order.
+    #
+    # Stored in speakers_json (not metadata_json) because speakers_json is
+    # one of the fields project_registry.yaml copies into Task.data at
+    # task-creation time, so it flows straight through into the downloaded
+    # project CSV as its own column -- metadata_json never appears there
+    # unless the (normally-unused) include_input_data_metadata_json export
+    # flag is set.
+    existing_sequence_ids = [
+        (speakers[0] or {}).get("sequence_id", 0)
+        for speakers in SpeechConversation.objects.filter(
+            instance_id=dataset_instance
+        ).values_list("speakers_json", flat=True)
+        if speakers
+    ]
+    next_sequence_id = max(existing_sequence_ids, default=0) + 1
+    for row in shoonya_rows:
+        speakers_list = json.loads(row["speakers_json"])
+        if speakers_list:
+            speakers_list[0]["sequence_id"] = next_sequence_id
+        row["speakers_json"] = json.dumps(speakers_list, ensure_ascii=False)
+        next_sequence_id += 1
 
     csv_string = build_shoonya_csv_string(shoonya_rows)
     report(
@@ -474,7 +509,11 @@ def create_projects_for_dataset_category(
         user_id (int): User triggering creation; set as creator/annotator/reviewer
     """
     from projects.models import BATCH, REVIEW_STAGE, Project
-    from projects.tasks import create_parameters_for_task_creation
+    from projects.tasks import (
+        add_new_data_items_into_project,
+        create_parameters_for_task_creation,
+        filter_data_items,
+    )
 
     SpeechConversation = apps.get_model("dataset", "SpeechConversation")
 
@@ -496,7 +535,7 @@ def create_projects_for_dataset_category(
     )
 
     created_projects = []
-    skipped_groups = []
+    topped_up_projects = []
 
     for domain in sorted(domains):
         _, part = parse_domain(domain)
@@ -520,34 +559,50 @@ def create_projects_for_dataset_category(
         latest_project, next_batch_number = get_latest_project_for_group(
             dataset_instance, language, part, category
         )
-        latest_project_under_capacity = (
-            latest_project is not None
-            and Task.objects.filter(project_id=latest_project).count() < limit
-        )
 
-        # A new batch is created immediately once every existing project for
-        # this group is already full (or there's no project yet at all) --
-        # regardless of count, same as a first-ever batch. It only waits when
-        # the most recent existing project is itself under capacity, since
-        # that's the one that should be topped up first rather than leaving
-        # two partially-filled projects side by side.
-        if latest_project_under_capacity and unassigned_count < limit:
-            skipped_groups.append(
-                {
-                    "domain": domain,
-                    "unassigned_count": unassigned_count,
-                    "limit": limit,
-                    "existing_project_id": latest_project.id,
-                    "existing_project_title": latest_project.title,
-                    "message": (
-                        f"{unassigned_count} unassigned task(s) available - pull them "
-                        f"into '{latest_project.title}' via its 'Pull New Data Items' "
-                        f"action, or wait for more uploads to auto-create the next batch."
-                    ),
-                }
-            )
+        # Top up the latest existing project first if it's under capacity --
+        # using only as many of the newly-unassigned items as needed to fill
+        # it (not more), so any surplus still goes toward a new batch below.
+        # Runs synchronously (not .delay()) so the just-created Task rows
+        # are visible to the unassigned-count recompute that follows,
+        # instead of racing an async pull.
+        if latest_project is not None:
+            deficit = limit - Task.objects.filter(project_id=latest_project).count()
+            if deficit > 0:
+                topup_filter_string = build_unassigned_filter_string(domain, last_assigned_id)
+                available_items = filter_data_items(
+                    latest_project.project_type,
+                    [dataset_instance.instance_id],
+                    topup_filter_string,
+                )
+                items_to_pull = available_items[:deficit]
+                if items_to_pull:
+                    # Captured before add_new_data_items_into_project runs --
+                    # it calls create_tasks_from_dataitems, which mutates
+                    # each item dict in place (`del item["id"]`) once it's
+                    # used to build the Task, so reading item["id"] after
+                    # that call would raise KeyError.
+                    pulled_ids = [item["id"] for item in items_to_pull]
+                    add_new_data_items_into_project(
+                        project_id=latest_project.id, items=items_to_pull
+                    )
+                    topped_up_projects.append(
+                        {
+                            "project_id": latest_project.id,
+                            "title": latest_project.title,
+                            "pulled_count": len(items_to_pull),
+                        }
+                    )
+                    last_assigned_id = max(pulled_ids)
+                    unassigned_count -= len(items_to_pull)
+
+        if unassigned_count == 0:
             continue
 
+        # Whatever's left after the top-up above always becomes a new batch
+        # immediately, however small -- by this point the latest existing
+        # project (if any) is guaranteed either full or completely out of
+        # data to give it, so there's nothing left to wait on.
         task_count = min(unassigned_count, limit)
         batch_number = next_batch_number
         title = build_project_title(language, part, category, batch_number)
@@ -605,44 +660,5 @@ def create_projects_for_dataset_category(
     return {
         "language": language,
         "created_projects": created_projects,
-        "skipped_groups": skipped_groups,
-    }
-
-
-def pull_unassigned_items_into_project(dataset_instance, domain, project_id):
-    """Pulls every currently-unassigned SpeechConversation item for `domain`
-    (within `dataset_instance`) into an already-existing project.
-
-    Deliberately does NOT reuse `projects.views.pull_new_items` -- that
-    action re-slices the project's own frozen `sampling_parameters_json`
-    batch window (fixed `batch_number`/`batch_size` from creation time), so
-    it keeps re-selecting the *original* already-assigned items forever
-    rather than picking up newly-unassigned ones. This instead re-derives
-    "currently unassigned" the same way `create_projects_for_dataset_category`
-    does (highest already-assigned id across ALL projects for this domain),
-    then pulls exactly that set.
-    """
-    from projects.models import Project
-    from projects.tasks import add_new_data_items_into_project, filter_data_items
-
-    project = Project.objects.get(pk=project_id)
-
-    last_assigned_id = (
-        Task.objects.filter(
-            project_id__dataset_id=dataset_instance,
-            input_data__speechconversation__domain=domain,
-        ).aggregate(Max("input_data_id"))["input_data_id__max"]
-        or 0
-    )
-    filter_string = build_unassigned_filter_string(domain, last_assigned_id)
-    items = filter_data_items(
-        project.project_type, [dataset_instance.instance_id], filter_string
-    )
-    if not items:
-        return {"message": "No unassigned items available to pull.", "pulled_count": 0}
-
-    add_new_data_items_into_project.delay(project_id=project.id, items=items)
-    return {
-        "message": f"Pulling {len(items)} item(s) into '{project.title}'.",
-        "pulled_count": len(items),
+        "topped_up_projects": topped_up_projects,
     }

--- a/backend/dataset/views.py
+++ b/backend/dataset/views.py
@@ -46,7 +46,6 @@ from .tasks import (
     deduplicate_dataset_instance_items,
     create_dataset_and_project_pipeline,
     create_projects_for_dataset_category,
-    pull_unassigned_items_into_project,
 )
 from .pipeline_utils import parse_input_csv, validate_input_csv, TASK_LIMITS
 import dataset
@@ -242,7 +241,7 @@ class DatasetInstanceViewSet(viewsets.ModelViewSet):
         "start_pipeline",
         "pipeline_progress",
         "create_pipeline_projects",
-        "pull_pipeline_project_items",
+        "pipeline_dataset_language",
     ]
 
     def get_permissions(self):
@@ -515,39 +514,60 @@ class DatasetInstanceViewSet(viewsets.ModelViewSet):
 
         existing_instance_id = request.POST.get("existing_instance_id") or None
         deduplicate = request.POST.get("deduplicate", "false").lower() == "true"
+        declared_language = request.POST.get("language") or None
 
-        # If adding to an existing dataset, the new CSV's language must match
-        # what's already in it -- each dataset is meant to hold a single
-        # language, and mixing languages would corrupt that invariant for
-        # every downstream domain/batch grouping. Checked here, synchronously,
-        # so the user gets immediate feedback instead of the async pipeline
-        # failing partway through (after audio has already been uploaded).
-        if existing_instance_id:
+        # Each dataset is meant to hold a single language throughout its
+        # life -- mixing languages would corrupt every downstream
+        # domain/batch grouping. Checked here, synchronously, so the user
+        # gets immediate feedback instead of the async pipeline failing
+        # partway through (after audio has already been uploaded).
+        if existing_instance_id or declared_language:
             rows, fieldnames = parse_input_csv(csv_string)
             validation = validate_input_csv(rows, fieldnames)
             if validation["valid"] and validation["languages"]:
                 new_language = validation["languages"][0]
-                try:
-                    dataset_instance = DatasetInstance.objects.get(pk=existing_instance_id)
-                except DatasetInstance.DoesNotExist:
-                    return Response(
-                        {"message": "Dataset instance not found."},
-                        status=status.HTTP_404_NOT_FOUND,
+
+                if existing_instance_id:
+                    # Adding to an existing dataset: must match what's
+                    # already in it.
+                    try:
+                        dataset_instance = DatasetInstance.objects.get(
+                            pk=existing_instance_id
+                        )
+                    except DatasetInstance.DoesNotExist:
+                        return Response(
+                            {"message": "Dataset instance not found."},
+                            status=status.HTTP_404_NOT_FOUND,
+                        )
+                    SpeechConversation = apps.get_model("dataset", "SpeechConversation")
+                    existing_language = (
+                        SpeechConversation.objects.filter(instance_id=dataset_instance)
+                        .exclude(language="")
+                        .values_list("language", flat=True)
+                        .first()
                     )
-                SpeechConversation = apps.get_model("dataset", "SpeechConversation")
-                existing_language = (
-                    SpeechConversation.objects.filter(instance_id=dataset_instance)
-                    .exclude(language="")
-                    .values_list("language", flat=True)
-                    .first()
-                )
-                if existing_language and existing_language != new_language:
+                    if existing_language and existing_language != new_language:
+                        return Response(
+                            {
+                                "message": (
+                                    f"Language mismatch: dataset '{dataset_instance.instance_name}' "
+                                    f"already contains '{existing_language}' data, but this CSV is "
+                                    f"'{new_language}'. Each dataset must contain a single language."
+                                )
+                            },
+                            status=status.HTTP_400_BAD_REQUEST,
+                        )
+                elif declared_language and declared_language != new_language:
+                    # Creating a new dataset: must match the language picked
+                    # in the "Configure Dataset" step (and baked into the
+                    # dataset's own <Language>-JT-... name).
                     return Response(
                         {
                             "message": (
-                                f"Language mismatch: dataset '{dataset_instance.instance_name}' "
-                                f"already contains '{existing_language}' data, but this CSV is "
-                                f"'{new_language}'. Each dataset must contain a single language."
+                                f"Language mismatch: this dataset is being created for "
+                                f"'{declared_language}', but the uploaded CSV is "
+                                f"'{new_language}'. Pick a matching language or upload a "
+                                f"CSV in that language."
                             )
                         },
                         status=status.HTTP_400_BAD_REQUEST,
@@ -609,6 +629,35 @@ class DatasetInstanceViewSet(viewsets.ModelViewSet):
         return Response(response_data, status=status.HTTP_200_OK)
 
     @is_organization_owner_or_admin
+    @action(methods=["GET"], detail=True, name="Get Dataset's Language For Pipeline")
+    def pipeline_dataset_language(self, request, pk):
+        """
+        Returns the (first non-empty) language found in this dataset
+        instance's items -- lets the Create Dataset & Project wizard warn
+        the user client-side, right after CSV validation, if the CSV they're
+        about to add doesn't match this existing dataset's language (instead
+        of only finding out after clicking "Start Pipeline").
+        URL: /data/instances/<pk>/pipeline_dataset_language/
+        Accepted methods: GET
+        """
+        try:
+            dataset_instance = DatasetInstance.objects.get(pk=pk)
+        except DatasetInstance.DoesNotExist:
+            return Response(
+                {"message": "Dataset instance not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        SpeechConversation = apps.get_model("dataset", "SpeechConversation")
+        language = (
+            SpeechConversation.objects.filter(instance_id=dataset_instance)
+            .exclude(language="")
+            .values_list("language", flat=True)
+            .first()
+        )
+        return Response({"language": language}, status=status.HTTP_200_OK)
+
+    @is_organization_owner_or_admin
     @action(methods=["POST"], detail=False, name="Create Projects For Dataset Category")
     def create_pipeline_projects(self, request):
         """
@@ -656,50 +705,6 @@ class DatasetInstanceViewSet(viewsets.ModelViewSet):
             return Response({"message": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(result, status=status.HTTP_201_CREATED)
-
-    @is_organization_owner_or_admin
-    @action(methods=["POST"], detail=False, name="Pull Unassigned Items Into Existing Project")
-    def pull_pipeline_project_items(self, request):
-        """
-        Pulls every currently-unassigned item for a domain (within a dataset
-        instance) into an already-existing project -- used by the Create
-        Project tab's "Pull N Task(s) Into '<project>'" button, when a group
-        is below its batch threshold but an earlier project already covers it.
-        This is deliberately separate from projects.views.pull_new_items,
-        which re-slices a frozen batch window and isn't a fit here (see
-        pull_unassigned_items_into_project's docstring).
-        URL: /data/instances/pull_pipeline_project_items/
-        Accepted methods: POST
-        Body: {"instance_id": int, "domain": str, "project_id": int}
-        """
-        instance_id = request.data.get("instance_id")
-        domain = request.data.get("domain")
-        project_id = request.data.get("project_id")
-
-        if not instance_id or not domain or not project_id:
-            return Response(
-                {"message": "instance_id, domain, and project_id are required."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        try:
-            dataset_instance = DatasetInstance.objects.get(pk=instance_id)
-        except DatasetInstance.DoesNotExist:
-            return Response(
-                {"message": "Dataset instance not found."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
-        try:
-            result = pull_unassigned_items_into_project(
-                dataset_instance=dataset_instance,
-                domain=domain,
-                project_id=project_id,
-            )
-        except apps.get_model("projects", "Project").DoesNotExist:
-            return Response({"message": "Project not found."}, status=status.HTTP_404_NOT_FOUND)
-
-        return Response(result, status=status.HTTP_200_OK)
 
     @is_organization_owner
     @action(methods=["GET"], detail=True, name="List all Projects using Dataset")


### PR DESCRIPTION
## Description

This PR introduces pipeline enhancements for the dataset creation workflow, primarily focusing on strict language validation during dataset uploads and automating the project top-up process.

### New Features & Enhancements
- **Strict Language Checking:** Added robust language validation logic in the pipeline (`dataset/views.py`) to ensure that each dataset contains only a single language. This prevents downstream grouping corruption by failing synchronously when a CSV language mismatch occurs.
- **New Dataset Language API:** Implemented a new `pipeline_dataset_language` API endpoint. This allows the frontend to fetch the existing language of a dataset instance for immediate client-side validation before the heavy processing begins.
- **Auto Top-Up Integration:** Removed the standalone `pull_pipeline_project_items` endpoint. The process of pulling unassigned items into an existing project is now automatically handled as part of the core project creation and assignment logic, streamlining the process.

### Bug Fixes
- Prevents async pipeline failures that would previously occur midway through audio processing when users inadvertently uploaded mixed-language CSVs to single-language datasets.

### Testing Instructions
1. **Language Validation Endpoint:** Hit `GET /data/instances/<pk>/pipeline_dataset_language/` and ensure it returns the correct existing language for the dataset.
2. **Pipeline Restrictions:** Attempt to start a pipeline with a CSV that contains a different language than the dataset's existing or declared language. Ensure the request is rejected with a `400 Bad Request` and an appropriate error message.
3. **Auto Top-up:** Trigger the pipeline and verify that unassigned tasks are automatically pulled into existing under-capacity projects without requiring the legacy standalone API call.
