### PR TITLE
Feature/create dataset and project

### DIFF
--- a/backend/dataset/pipeline_utils.py
+++ b/backend/dataset/pipeline_utils.py
@@ -131,6 +131,11 @@ def validate_input_csv(rows, fieldnames):
             f"CSV contains multiple languages ({', '.join(sorted(languages))}). "
             "Each upload must contain a single language."
         )
+    if len(parts) > 1:
+        errors.append(
+            f"CSV contains multiple parts ({', '.join(sorted(parts))}). "
+            "Each upload must contain a single part."
+        )
 
     return {
         "valid": len(errors) == 0,
@@ -170,6 +175,7 @@ def build_shoonya_row(input_row, audio_url):
     raw_class = (input_row.get("Class") or "").strip()
     class_val = int(raw_class) if raw_class.isdigit() else raw_class
     delivery_date = (input_row.get("Date of delivery") or "").strip()
+    others = (input_row.get("Others") or "").strip()
 
     raw_metadata = (input_row.get("Metadata") or "").strip()
     metadata_dict = {}
@@ -182,6 +188,8 @@ def build_shoonya_row(input_row, audio_url):
     metadata_dict["user_id"] = raw_user_id
     metadata_dict["class"] = class_val
     metadata_dict["delivery_date"] = delivery_date
+    if others:
+        metadata_dict["others"] = others
 
     raw_verbatim = (input_row.get("Verbatim Transcription") or "").strip()
     segments = []

--- a/backend/dataset/pipeline_utils.py
+++ b/backend/dataset/pipeline_utils.py
@@ -169,6 +169,7 @@ def build_shoonya_row(input_row, audio_url):
     raw_user_id = (input_row.get("User ID") or "").strip()
     raw_class = (input_row.get("Class") or "").strip()
     class_val = int(raw_class) if raw_class.isdigit() else raw_class
+    delivery_date = (input_row.get("Date of delivery") or "").strip()
 
     raw_metadata = (input_row.get("Metadata") or "").strip()
     metadata_dict = {}
@@ -180,6 +181,7 @@ def build_shoonya_row(input_row, audio_url):
     metadata_dict["audio_id"] = audio_id
     metadata_dict["user_id"] = raw_user_id
     metadata_dict["class"] = class_val
+    metadata_dict["delivery_date"] = delivery_date
 
     raw_verbatim = (input_row.get("Verbatim Transcription") or "").strip()
     segments = []

--- a/backend/dataset/tasks.py
+++ b/backend/dataset/tasks.py
@@ -376,7 +376,7 @@ def create_dataset_and_project_pipeline(self, input_csv_string, config):
         dataset_instance = DatasetInstance.objects.get(pk=existing_instance_id)
     else:
         dataset_instance = DatasetInstance.objects.create(
-            instance_name=config.get("dataset_name") or f"{language}_JT",
+            instance_name=config.get("dataset_name") or language,
             dataset_type="SpeechConversation",
             organisation_id_id=organisation_id,
         )

--- a/backend/dataset/tasks.py
+++ b/backend/dataset/tasks.py
@@ -419,33 +419,43 @@ def create_dataset_and_project_pipeline(self, input_csv_string, config):
                 seen_audio_urls.add(row["audio_url"])
         shoonya_rows = deduped_rows
 
-    # Tag each row actually being inserted with a per-dataset sequence_id
-    # (1, 2, 3, ...), continuing from the highest sequence_id already used
-    # in this dataset instance across all previous uploads -- e.g. 12
-    # entries uploaded first get 1-12, then 10 more uploaded later get
-    # 13-22. Assigned after dedup so skipped duplicates don't consume a
-    # number. Rows preserve their upload/CSV order.
+    # Tag each row actually being inserted with a sequence_id (1, 2, 3, ...)
+    # tracked separately per category (Read / Extempore each have their own
+    # counter, continuing from the highest sequence_id already used *for
+    # that category* in this dataset instance) -- matches how their task
+    # limits/batches are already independent of each other. E.g. if Read
+    # has 1-12 and Extempore has 1-8, a further Read upload continues at
+    # 13, and a further Extempore upload continues at 9. Assigned after
+    # dedup so skipped duplicates don't consume a number. Rows preserve
+    # their upload/CSV order.
     #
-    # Stored in speakers_json (not metadata_json) because speakers_json is
-    # one of the fields project_registry.yaml copies into Task.data at
-    # task-creation time, so it flows straight through into the downloaded
-    # project CSV as its own column -- metadata_json never appears there
-    # unless the (normally-unused) include_input_data_metadata_json export
-    # flag is set.
-    existing_sequence_ids = [
-        (speakers[0] or {}).get("sequence_id", 0)
-        for speakers in SpeechConversation.objects.filter(
-            instance_id=dataset_instance
-        ).values_list("speakers_json", flat=True)
-        if speakers
-    ]
-    next_sequence_id = max(existing_sequence_ids, default=0) + 1
+    # Stored in metadata_json: process_task() (projects/utils.py) now always
+    # copies the dataset item's metadata_json into the downloaded project
+    # CSV as its own "input_data_metadata_json" column, so this flows
+    # through there without needing speakers_json's special-cased export.
+    max_sequence_id_by_category = {}
+    for category, metadata in SpeechConversation.objects.filter(
+        instance_id=dataset_instance
+    ).values_list("scenario", "metadata_json"):
+        if not metadata:
+            continue
+        sequence_id = metadata.get("sequence_id", 0)
+        max_sequence_id_by_category[category] = max(
+            max_sequence_id_by_category.get(category, 0), sequence_id
+        )
+
+    next_sequence_id_by_category = {
+        category: max_sequence_id_by_category.get(category, 0) + 1
+        for category in TASK_LIMITS
+    }
     for row in shoonya_rows:
-        speakers_list = json.loads(row["speakers_json"])
-        if speakers_list:
-            speakers_list[0]["sequence_id"] = next_sequence_id
-        row["speakers_json"] = json.dumps(speakers_list, ensure_ascii=False)
-        next_sequence_id += 1
+        category = row["scenario"]
+        metadata_dict = json.loads(row["metadata_json"])
+        metadata_dict["sequence_id"] = next_sequence_id_by_category.get(category, 1)
+        row["metadata_json"] = json.dumps(metadata_dict, ensure_ascii=False)
+        next_sequence_id_by_category[category] = (
+            next_sequence_id_by_category.get(category, 1) + 1
+        )
 
     csv_string = build_shoonya_csv_string(shoonya_rows)
     report(

--- a/backend/projects/utils.py
+++ b/backend/projects/utils.py
@@ -569,6 +569,20 @@ def get_audio_transcription_text(annotation_result):
     return text.strip()
 
 
+def move_sequence_id_last(metadata_json):
+    """Postgres jsonb does not preserve object-key insertion order -- it
+    reorders keys by (length, then lexicographically) on every write/read,
+    so "sequence_id" can land anywhere depending on the other keys' lengths.
+    Move it to the end here, at export time, so downloaded CSVs consistently
+    show it last regardless of how jsonb chose to store it.
+    """
+    if not isinstance(metadata_json, dict) or "sequence_id" not in metadata_json:
+        return metadata_json
+    metadata_json = dict(metadata_json)
+    metadata_json["sequence_id"] = metadata_json.pop("sequence_id")
+    return metadata_json
+
+
 def process_task(
     task,
     export_type,
@@ -609,10 +623,20 @@ def process_task(
 
     task_dict["data"]["annotator_email"] = annotator_email
 
-    if include_input_data_metadata_json and dataset_model:
-        task_dict["data"]["input_data_metadata_json"] = dataset_model.objects.get(
-            pk=task_dict["input_data"]
-        ).metadata_json
+    # Always include the dataset item's own metadata_json as its own CSV
+    # column on every download -- previously this only appeared when the
+    # include_input_data_metadata_json query param was set, which the
+    # standard "Download Project" button never sends. task.input_data is
+    # already fetched (the download queryset select_relateds it), so this
+    # needs no extra query.
+    if task.input_data is not None:
+        task_dict["data"]["metadata_json"] = move_sequence_id_last(
+            task.input_data.metadata_json
+        )
+    elif include_input_data_metadata_json and dataset_model:
+        task_dict["data"]["metadata_json"] = move_sequence_id_last(
+            dataset_model.objects.get(pk=task_dict["input_data"]).metadata_json
+        )
     try:
         if fetch_parent_data_field and dataset_model:
             parent_data_item = dataset_model.objects.get(


### PR DESCRIPTION
- **Strict "Part" Validation:** Added a new validation check in the CSV upload pipeline (`dataset/pipeline_utils.py`). The pipeline will now synchronously reject uploads if a single CSV contains multiple distinct "Parts". This ensures that each dataset ingestion batch remains strictly uniform.
### Bug Fixes
- Addressed merge conflicts in `CreateDatasetAndProject.jsx` to ensure seamless integration with the master branch while retaining the newly introduced workflow logic.
### UI Changes
* The "Dataset Name" input field has been removed and replaced by an informational banner that displays the automatically derived dataset name.
* The "Language" dropdown is now clearly isolated as the primary configuration choice.
### Testing Instructions
1. Navigate to the Create Dataset & Project page.
2. Select "Create a New Dataset". Notice that the manual naming field is gone and the auto-generated name correctly reads `<Language>-PartA-childDS`.
3. Try uploading a CSV file containing multiple different parts in the `Part` column; verify that the backend cleanly rejects it with an error.
4. Try uploading a CSV file with a language that does not match your dropdown selection; verify that the frontend rejects it client-side.